### PR TITLE
Create containerised setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:24.04
+
+# set working directory
+WORKDIR /app
+
+COPY pyproject.toml .
+COPY README.md .
+COPY zarr_creator ./zarr_creator
+COPY build_indexes_and_refs.sh .
+COPY run.sh .
+
+RUN apt-get update
+RUN apt-get install -y curl git rsync
+RUN apt-get install -y libaec0 libaec-dev
+
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Setup up PATH for uv
+ENV PATH="/root/.local/bin:$PATH"
+
+# Create venv with python3.12 (3.13 didn't work with some deps)
+RUN uv venv -p 3.12
+RUN uv sync
+
+ENTRYPOINT ["./run.sh"]

--- a/build_indexes_and_refs.sh
+++ b/build_indexes_and_refs.sh
@@ -42,6 +42,8 @@
 # fail if any variables used are not defined, this ensures we don't try copying
 # to TEMP_ROOT if it's not set
 set -u
+# fail if any command has non-zero exit code
+set -e
 
 ANALYSIS_TIME=$1
 ROOT_PATH="/mnt/harmonie-data-from-pds/ml"
@@ -121,7 +123,7 @@ for type in sf pl; do
     uv run python -m zarr_creator.build_indexes $SRC_PATH/fc${ANALYSIS_TIME_STR}+0{00..36}${MEMBER_ID}_${type} -n 2
 
     echo "Building refs for $type files"
-    gribscan-build $SRC_PATH/fc${ANALYSIS_TIME_STR}+???${MEMBER_ID}_${type}.index \
+    uv run gribscan-build $SRC_PATH/fc${ANALYSIS_TIME_STR}+???${MEMBER_ID}_${type}.index \
         -o ${REFS_ROOT_PATH}/${MEMBER_ID}/${ANALYSIS_TIME//:/}.jsons\
         --prefix $SRC_PATH/ \
         -m harmonie

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,13 @@ dependencies = [
     "s3fs>=2025.2.0",
     "cf-xarray>=0.10.0",
     "scipy==1.15.3",
-    "eccodes==2.37.0",
     "isodate>=0.7.2",
     "gribscan",
+    "eccodeslib==2.42.0",
+    "eccodes==2.42.0",
+    "zarr>2.18.6",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 readme = "README.md"
 license = {text = "MIT"}
 

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
+#!/bin/bash
 # every hour run the script
 REFS_ROOT_PATH="/home/ec2-user/nwp-forecast-zarr-creator/refs"
-TEMP_ROOT="$HOME/tmp"
+TEMP_ROOT="/tmp/nwp-forecast-zarr-creator"
 
 while true; do
     # find the nearest three hour interval to the current time, e.g. 00:00,
@@ -28,6 +29,7 @@ while true; do
         continue
     else
         echo "Creating indexes refs for analysis time $analysis_time"
+        echo "(calling ./build_indexes_and_refs.sh $analysis_time $TEMP_ROOT)"
         ./build_indexes_and_refs.sh $analysis_time $TEMP_ROOT
 
         # check if the script was successful with the exit code

--- a/zarr_creator/__main__.py
+++ b/zarr_creator/__main__.py
@@ -10,12 +10,15 @@ from loguru import logger
 
 from . import __version__
 from .config import DATA_COLLECTION
+from .grib_definitions import set_local_eccodes_definitions_path
 from .read_source import read_level_type_data
 from .write_zarr import write_zarr_to_s3
 
 DEFAULT_ANALYSIS_TIME = "2025-02-17T01:00:00Z"
 DEFAULT_FORECAST_DURATION = "PT3H"
 DEFAULT_CHUNKING = dict(time=54, x=300, y=260)
+
+set_local_eccodes_definitions_path()
 
 
 def _setup_argparse():

--- a/zarr_creator/grib_definitions.py
+++ b/zarr_creator/grib_definitions.py
@@ -7,6 +7,7 @@ with eccodes.
 import importlib.resources as pkg_resources
 
 import eccodes
+from loguru import logger
 
 # pkg_resources.path requires that we provide the path to a file, so we give a
 # temporary filename (pkg_resources.path() will create and immediately delete
@@ -38,11 +39,17 @@ def set_local_eccodes_definitions_path():
     #    definitions in memory (so this works even though the `/MEMFS/` path
     #    doesn't actually exist). So we need to add that prefix to our path.
 
+    p_default = "/MEMFS/definitions"
+
     # doesn't work, see above
     # eccodes.codes_set_definitions_path(LOCAL_GRIB_DEFNS_PATH)
+    # p = str(LOCAL_GRIB_DEFNS_PATH)
 
     # works, lol
-    eccodes.codes_set_definitions_path(f"{LOCAL_GRIB_DEFNS_PATH}:/MEMFS/definitions")
+    p = f"{LOCAL_GRIB_DEFNS_PATH}:{p_default}"
+
+    logger.info(f"Setting eccodes definitions path to: {p}")
+    eccodes.codes_set_definitions_path(p)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Drop support for python3.10 (zarr>2.18.6 requires this, and we have to use zarr>2.18.6 to upstream change in numcodecs). Use python eccodes bindings `2.42.0` which rely on `eccodeslib==2.42.0` which means we have to run in container so that we have more recent operating system that Amazon Linux 2. We are dropping running outside of container in Amazon Linux because system eccodes (`v2.30.0`) keep crashing with python bindings (see README for details).