### PR TITLE
Add option for local copy and add cf attrs

### DIFF
--- a/zarr_creator/__main__.py
+++ b/zarr_creator/__main__.py
@@ -3,6 +3,7 @@
 import argparse
 import datetime
 import sys
+from pathlib import Path
 
 import isodate
 import xarray as xr
@@ -17,6 +18,8 @@ from .write_zarr import write_zarr_to_s3
 DEFAULT_ANALYSIS_TIME = "2025-02-17T01:00:00Z"
 DEFAULT_FORECAST_DURATION = "PT3H"
 DEFAULT_CHUNKING = dict(time=54, x=300, y=260)
+LOCAL_COPY_STORAGE_PATH = Path("/tmp/dini-recent")
+
 
 set_local_eccodes_definitions_path()
 
@@ -135,6 +138,7 @@ def cli(argv=None):
             dataset_id=part_id,
             rechunk_to=rechunk_to,
             t_analysis=args.t_analysis,
+            local_copy_path=LOCAL_COPY_STORAGE_PATH,
         )
 
 

--- a/zarr_creator/read_source.py
+++ b/zarr_creator/read_source.py
@@ -30,6 +30,11 @@ def read_level_type_data(t_analysis: datetime.datetime, level_type: str) -> xr.D
     # add cf-complicant projection information
     _add_projection_info(ds)
 
+    # set cf-compliant standard_name for axes time, x and y
+    ds.time.attrs["standard_name"] = "time"
+    ds.x.attrs["standard_name"] = "projection_x_coordinate"
+    ds.y.attrs["standard_name"] = "projection_y_coordinate"
+
     return ds
 
 


### PR DESCRIPTION
Change default behaviour so that as well as writing zarrs to S3 bucket the most recent forecast is also written to `/tmp/dini-recent`. This was added to enable running of DINI forecast visualisation on the EC2 instance.