### PR TITLE
update changelog for v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.5.0]
+### Added
+- Keep local copy of most recent forecast in `/tmp/dini-recent`
+  [\#12](https://github.com/dmidk/nwp-forecast-zarr-creator/pull/12),
+  @leifdenby
+- Containerise setup so we can use `eccodes==2.42.0` with `eccodeslib` for C
+  library rather than rely on system `eccodes` C lib
+  [\#11](https://github.com/dmidk/nwp-forecast-zarr-creator/pull/11), @leifdenby
+
+---
+
 ## [v0.4.0]
 ### Added
 - Land–sea mask extraction (`0cdf848`) and
@@ -15,14 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that `gribscan` can pick up the WMO standard GRIB2 definitions that DMI uses.
   Also bundles these local definitions with the package.
   [\#9](https://github.com/dmidk/nwp-forecast-zarr-creator/pull/9), @leifdenby
-- Keep local copy of most recent forecast in `/tmp/dini-recent`
-  [\#12](https://github.com/dmidk/nwp-forecast-zarr-creator/pull/12),
-  @leifdenby
-
-### Added
-- Containerise setup so we can use `eccodes==2.42.0` with `eccodeslib` for C
-  library rather than rely on system `eccodes` C lib
-  [\#11](https://github.com/dmidk/nwp-forecast-zarr-creator/pull/11), @leifdenby
 
 ---
 


### PR DESCRIPTION
In #12 I made mistake in the changelog and put additions into the heading for version `v0.4.0` even though they should have been for the next release (`v0.5.0`)