### PR TITLE
add orography (geopotential at 0m)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added vertical velocity, `tw`, on pressure levels to zarr output. [\#24](https://github.com/dmidk/nwp-forecast-zarr-creator/pull/24), @khintz
+- Added orography, ´z0m´, on single levels to zarr output. [\#26](https://github.com/dmidk/nwp-forecast-zarr-creator/pull/26), @khintz
 
 ### Maintenance
 

--- a/zarr_creator/config.py
+++ b/zarr_creator/config.py
@@ -26,7 +26,7 @@ DATA_COLLECTION = OrderedDict(
                     # "pstbc", # not in DINI
                     # "sf", # not in DINI
                     # "xhail", # not in DINI
-                    "lsm"
+                    "lsm",
                 ]
             },
         ),

--- a/zarr_creator/config.py
+++ b/zarr_creator/config.py
@@ -26,7 +26,7 @@ DATA_COLLECTION = OrderedDict(
                     # "pstbc", # not in DINI
                     # "sf", # not in DINI
                     # "xhail", # not in DINI
-                    "lsm",
+                    "lsm"
                 ]
             },
         ),
@@ -41,6 +41,7 @@ DATA_COLLECTION = OrderedDict(
                 "lwavr": None,
                 "lwavr_accum": None,
                 "vis": None,
+                "z": None,
             },
             level_name_mapping="{var_name}0m",
         ),


### PR DESCRIPTION
Adds orography to the zarr dataset as geopotential at 0m. The variable in the zarr output is called `z0m`. Would be best to call it `orograhpy` but then we are back to the discussion in https://github.com/dmidk/nwp-forecast-zarr-creator/issues/22#issuecomment-4108347160