### PR TITLE
Add support for ig GRIB files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "zarr_creator"
 dynamic = ["version"]
-description = "zarr creation from harmonie dini forecasts"
+description = "zarr creation from harmonie dini and ig forecasts"
 authors = [
     {name = "Kasper Stener Hintz", email = "kah@dmi.dk"},
     {name = "Eleni Briola", email = "elb@dmi.dk"},

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,7 @@ source "${SCRIPT_DIR}/script_defaults.sh"
 echo "SRC_GRIB_ROOT_PATH: ${SRC_GRIB_ROOT_PATH}"
 echo "REFS_ROOT_PATH: ${REFS_ROOT_PATH}"
 echo "SRC_GRIB_TEMP_PATH: ${SRC_GRIB_TEMP_PATH:-not set}"
+echo "SUITE_NAME: ${SUITE_NAME}"
 
 while true; do
     # find the nearest three hour interval to the current time, e.g. 00:00,
@@ -55,7 +56,7 @@ while true; do
         echo "Running zarr conversion for analysis time $analysis_time"
 
         while true; do
-            uv run python -m zarr_creator --t_analysis "$analysis_time"
+            uv run python -m zarr_creator --t_analysis "$analysis_time" --suite-name "$SUITE_NAME"
             # check if the script was successful with the exit code
             if [ $? -eq 0 ]; then
                 # delete temporary storage if it was used

--- a/zarr_creator/__main__.py
+++ b/zarr_creator/__main__.py
@@ -24,7 +24,7 @@ from .write_zarr import write_output_zarrs
 DEFAULT_ANALYSIS_TIME = "2025-02-17T01:00:00Z"
 DEFAULT_FORECAST_DURATION = "PT3H"
 DEFAULT_CHUNKING = dict(time=54, x=300, y=260)
-LOCAL_COPY_STORAGE_PATH = Path("/tmp/dini-recent")
+LOCAL_COPY_STORAGE_PATH = Path("/tmp/{suite_name}-recent")
 
 set_local_eccodes_definitions_path()
 
@@ -54,7 +54,7 @@ def _setup_argparse():
         action="store_true",
         help=(
             "If provided, skip uploading zarr outputs to the S3 bucket. "
-            "A local copy is still written to /tmp/dini-recent."
+            "A local copy is still written to /tmp/{suite-name}-recent."
         ),
     )
 
@@ -90,6 +90,8 @@ def cli(argv=None):
     else:
         raise ValueError(f"Unsupported suite name: {args.suite_name}")
 
+    local_copy_path = LOCAL_COPY_STORAGE_PATH.format(suite_name=args.suite_name)
+    
     parts = {}
     for part_id, part_details in data_collection.items():
         ds_part = xr.Dataset()
@@ -183,8 +185,9 @@ def cli(argv=None):
             dataset_id=part_id,
             rechunk_to=rechunk_to,
             t_analysis=args.t_analysis,
+            suite_name=args.suite_name,
             skip_s3_bucket_upload=args.skip_s3_bucket_upload,
-            local_copy_path=LOCAL_COPY_STORAGE_PATH,
+            local_copy_path=local_copy_path,
         )
 
 

--- a/zarr_creator/__main__.py
+++ b/zarr_creator/__main__.py
@@ -6,11 +6,17 @@ import sys
 from pathlib import Path
 
 import isodate
+import numpy as np
 import xarray as xr
 from loguru import logger
 
 from . import __version__
-from .config import DATA_COLLECTION
+from .config_dini import DATA_COLLECTION as DINI_DATA_COLLECTION
+from .config_dini import PROJECTION_IDENTIFIER as DINI_PROJECTION_IDENTIFIER
+from .config_dini import PROJECTION_WKT as DINI_PROJECTION_WKT
+from .config_ig import DATA_COLLECTION as IG_DATA_COLLECTION
+from .config_ig import PROJECTION_IDENTIFIER as IG_PROJECTION_IDENTIFIER
+from .config_ig import PROJECTION_WKT as IG_PROJECTION_WKT
 from .grib_definitions import set_local_eccodes_definitions_path
 from .read_source import read_level_type_data
 from .write_zarr import write_output_zarrs
@@ -52,6 +58,13 @@ def _setup_argparse():
         ),
     )
 
+    argparser.add_argument(
+        "--suite-name",
+        help="The suite with corresponding config file to use (e.g. 'ig', 'dini', etc.)",
+        choices=["ig", "dini"],
+        required=True,
+    )
+
     return argparser
 
 
@@ -66,8 +79,19 @@ def cli(argv=None):
     logger.remove()
     logger.add(sys.stderr, level=args.log_level.upper())
 
+    if args.suite_name == "ig":
+        data_collection = IG_DATA_COLLECTION
+        projection_identifier = IG_PROJECTION_IDENTIFIER
+        projection_wkt = IG_PROJECTION_WKT
+    elif args.suite_name == "dini":
+        data_collection = DINI_DATA_COLLECTION
+        projection_identifier = DINI_PROJECTION_IDENTIFIER
+        projection_wkt = DINI_PROJECTION_WKT
+    else:
+        raise ValueError(f"Unsupported suite name: {args.suite_name}")
+
     parts = {}
-    for part_id, part_details in DATA_COLLECTION.items():
+    for part_id, part_details in data_collection.items():
         ds_part = xr.Dataset()
         for level_details in part_details:
             level_type = level_details["level_type"]
@@ -75,7 +99,10 @@ def cli(argv=None):
             level_name_mapping = level_details.get("level_name_mapping", None)
 
             ds_level_type = read_level_type_data(
-                t_analysis=args.t_analysis, level_type=level_type
+                t_analysis=args.t_analysis,
+                level_type=level_type,
+                projection_identifier=projection_identifier,
+                projection_wkt=projection_wkt,
             )
 
             for var_name, levels in variables.items():
@@ -133,10 +160,11 @@ def cli(argv=None):
         parts[part_id] = ds_part
 
     for part_id, ds_part in parts.items():
-        rechunk_to = dict(time=1, x=ds_part.x.size // 2, y=ds_part.y.size // 2)
-        # check that with the chunking provided that the arrays exactly fit into the chunks
-        for dim in rechunk_to:
-            assert ds_part[dim].size % rechunk_to[dim] == 0
+        rechunk_to = dict(
+            time=1,
+            x=int(np.ceil(ds_part.x.size / 2)),
+            y=int(np.ceil(ds_part.y.size / 2)),
+        )
 
         # set zarr-creator version
         ds_part.attrs["zarr_creator_version"] = __version__

--- a/zarr_creator/__main__.py
+++ b/zarr_creator/__main__.py
@@ -91,7 +91,7 @@ def cli(argv=None):
         raise ValueError(f"Unsupported suite name: {args.suite_name}")
 
     local_copy_path = LOCAL_COPY_STORAGE_PATH.format(suite_name=args.suite_name)
-    
+
     parts = {}
     for part_id, part_details in data_collection.items():
         ds_part = xr.Dataset()

--- a/zarr_creator/__main__.py
+++ b/zarr_creator/__main__.py
@@ -3,7 +3,6 @@
 import argparse
 import datetime
 import sys
-from pathlib import Path
 
 import isodate
 import numpy as np
@@ -24,7 +23,7 @@ from .write_zarr import write_output_zarrs
 DEFAULT_ANALYSIS_TIME = "2025-02-17T01:00:00Z"
 DEFAULT_FORECAST_DURATION = "PT3H"
 DEFAULT_CHUNKING = dict(time=54, x=300, y=260)
-LOCAL_COPY_STORAGE_PATH = Path("/tmp/{suite_name}-recent")
+LOCAL_COPY_STORAGE_PATH = "/tmp/{suite_name}-recent"
 
 set_local_eccodes_definitions_path()
 

--- a/zarr_creator/config_dini.py
+++ b/zarr_creator/config_dini.py
@@ -1,0 +1,179 @@
+# The "data collection" may contain multiple named parts (each will be put in its own zarr archive)
+# Each part may contain multiple "level types" (e.g. heightAboveGround, etc)
+# and a name-mapping may also be defined
+from collections import OrderedDict
+
+from .transforms import derive_orography_from_geopotential
+
+PROJECTION_IDENTIFIER = "dini_projection"
+PROJECTION_WKT = """
+PROJCRS["DMI HARMONIE DINI lambert projection",
+    BASEGEOGCRS["DMI HARMONIE DINI lambert CRS",
+        DATUM["DMI HARMONIE DINI lambert datum",
+            ELLIPSOID["Sphere", 6371229, 0,
+                LENGTHUNIT["metre", 1,
+                    ID["EPSG", 9001]
+                ]
+            ]
+        ],
+        PRIMEM["Greenwich", 0,
+            ANGLEUNIT["degree", 0.0174532925199433,
+                ID["EPSG", 9122]
+            ]
+        ]
+    ],
+    CONVERSION["Lambert Conic Conformal (2SP)",
+        METHOD["Lambert Conic Conformal (2SP)",
+            ID["EPSG", 9802]
+        ],
+        PARAMETER["Latitude of false origin", 55.5,
+            ANGLEUNIT["degree", 0.0174532925199433,
+                ID["EPSG", 8821]
+            ]
+        ],
+        PARAMETER["Longitude of false origin", -8,
+            ANGLEUNIT["degree", 0.0174532925199433,
+                ID["EPSG", 8822]
+            ]
+        ],
+        PARAMETER["Latitude of 1st standard parallel", 55.5,
+            ANGLEUNIT["degree", 0.0174532925199433,
+                ID["EPSG", 8823]
+            ]
+        ],
+        PARAMETER["Latitude of 2nd standard parallel", 55.5,
+            ANGLEUNIT["degree", 0.0174532925199433,
+                ID["EPSG", 8824]
+            ]
+        ],
+        PARAMETER["Easting at false origin", 0,
+            LENGTHUNIT["metre", 1],
+            ID["EPSG", 8826]
+        ],
+        PARAMETER["Northing at false origin", 0,
+            LENGTHUNIT["metre", 1],
+            ID["EPSG", 8827]
+        ]
+    ],
+    CS[Cartesian, 2],
+    AXIS["(E)", east,
+        ORDER[1],
+        LENGTHUNIT["Metre", 1]
+    ],
+    AXIS["(N)", north,
+        ORDER[2],
+        LENGTHUNIT["Metre", 1]
+    ],
+    USAGE[
+        AREA["Denmark and surrounding regions"],
+        BBOX[37, -43, 70, 40],
+        SCOPE["DINI Harmonie forecast projection"]
+    ]
+]
+""".strip()
+
+DATA_COLLECTION = OrderedDict(
+    single_levels=[
+        dict(
+            level_type="heightAboveGround",
+            variables={
+                v: None
+                for v in [
+                    "hcc",
+                    "lcc",
+                    "mcc",
+                    # "total cloud cover" is present in DINI but as `cc`
+                    # shortname (according to kah@dmi.dk), but using the WMO
+                    # standard units of "percent" rather than a fraction
+                    # "tcc",
+                    # "icei", # not in DINI
+                    "mld",
+                    # "prtp", # not in DINI
+                    # "psct", # not in DINI
+                    # "pscw", # not in DINI
+                    # "pstb", # not in DINI
+                    # "pstbc", # not in DINI
+                    # "sf", # not in DINI
+                    # "xhail", # not in DINI
+                    "lsm",
+                ]
+            },
+        ),
+        # we include these separately from the other heightAboveGround
+        # variables because we want to include the `0m`-suffix in the variable
+        # name, to make it clear that these are surface variables
+        dict(
+            level_type="heightAboveGround",
+            variables={
+                "swavr": None,
+                "swavr_accum": None,
+                "lwavr": None,
+                "lwavr_accum": None,
+                "vis": None,
+            },
+            level_name_mapping="{var_name}0m",
+        ),
+        dict(
+            level_type="heightAboveGround",
+            variables={
+                "orography": lambda ds: derive_orography_from_geopotential(ds["z"]),
+            },
+        ),
+        dict(
+            level_type="heightAboveGround",
+            variables={
+                "t": [0, 2],
+                "pres": [0],
+                "r": [2],
+                "u": [10],
+                "v": [10],
+            },
+            level_name_mapping="{var_name}{level:d}m",
+        ),
+        dict(
+            level_type="entireAtmosphere",
+            variables={v: None for v in ["cape"]},  # pwat, cb, ct, grpl not in DINI
+            level_name_mapping="{var_name}_column",
+        ),
+        dict(
+            level_type="heightAboveSea",
+            variables=dict(pres=None),
+            level_name_mapping="{var_name}_seasurface",
+        ),
+    ],
+    pressure_levels=[
+        dict(
+            level_type="isobaricInhPa",
+            variables={
+                v: [
+                    1000,
+                    950,
+                    925,
+                    900,
+                    850,
+                    800,
+                    700,
+                    600,
+                    500,
+                    400,
+                    300,
+                    250,
+                    200,
+                    100,
+                ]
+                # for v in "z t u v tw r ciwc cwat".split()  # variables in DANRA
+                for v in "z t u v r tw".split()
+            },
+        )
+    ],
+    height_levels=[
+        dict(
+            level_type="heightAboveGround",
+            variables={
+                # v: [30, 50, 75, 100, 150, 200, 250, 300, 500]  # levels in DANRA
+                v: [50, 100, 150, 250]  # only these in DINI
+                for v in "t r u v".split()
+            },
+        )
+    ],
+)

--- a/zarr_creator/config_ig.py
+++ b/zarr_creator/config_ig.py
@@ -5,6 +5,73 @@ from collections import OrderedDict
 
 from .transforms import derive_orography_from_geopotential
 
+PROJECTION_IDENTIFIER = "ig_projection"
+PROJECTION_WKT = """
+PROJCRS["DMI HARMONIE IG lambert projection",
+    BASEGEOGCRS["DMI HARMONIE IG lambert CRS",
+        DATUM["DMI HARMONIE IG lambert datum",
+            ELLIPSOID["Sphere", 6371229, 0,
+                LENGTHUNIT["metre", 1,
+                    ID["EPSG", 9001]
+                ]
+            ]
+        ],
+        PRIMEM["Greenwich", 0,
+            ANGLEUNIT["degree", 0.0174532925199433,
+                ID["EPSG", 9122]
+            ]
+        ]
+    ],
+    CONVERSION["Lambert Conic Conformal (2SP)",
+        METHOD["Lambert Conic Conformal (2SP)",
+            ID["EPSG", 9802]
+        ],
+        PARAMETER["Latitude of false origin", 55.5,
+            ANGLEUNIT["degree", 0.0174532925199433,
+                ID["EPSG", 8821]
+            ]
+        ],
+        PARAMETER["Longitude of false origin", -8,
+            ANGLEUNIT["degree", 0.0174532925199433,
+                ID["EPSG", 8822]
+            ]
+        ],
+        PARAMETER["Latitude of 1st standard parallel", 55.5,
+            ANGLEUNIT["degree", 0.0174532925199433,
+                ID["EPSG", 8823]
+            ]
+        ],
+        PARAMETER["Latitude of 2nd standard parallel", 55.5,
+            ANGLEUNIT["degree", 0.0174532925199433,
+                ID["EPSG", 8824]
+            ]
+        ],
+        PARAMETER["Easting at false origin", 0,
+            LENGTHUNIT["metre", 1],
+            ID["EPSG", 8826]
+        ],
+        PARAMETER["Northing at false origin", 0,
+            LENGTHUNIT["metre", 1],
+            ID["EPSG", 8827]
+        ]
+    ],
+    CS[Cartesian, 2],
+    AXIS["(E)", east,
+        ORDER[1],
+        LENGTHUNIT["Metre", 1]
+    ],
+    AXIS["(N)", north,
+        ORDER[2],
+        LENGTHUNIT["Metre", 1]
+    ],
+    USAGE[
+        AREA["Denmark and surrounding regions"],
+        BBOX[37, -43, 70, 40],
+        SCOPE["IG Harmonie forecast projection"]
+    ]
+]
+""".strip()
+
 DATA_COLLECTION = OrderedDict(
     single_levels=[
         dict(
@@ -38,9 +105,9 @@ DATA_COLLECTION = OrderedDict(
         dict(
             level_type="heightAboveGround",
             variables={
-                "swavr": None,
+                # "swavr": None,
                 "swavr_accum": None,
-                "lwavr": None,
+                # "lwavr": None,
                 "lwavr_accum": None,
                 "vis": None,
             },

--- a/zarr_creator/config_ig.py
+++ b/zarr_creator/config_ig.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from .transforms import derive_orography_from_geopotential
 
 PROJECTION_IDENTIFIER = "ig_projection"
-# Note this WKT string gives consistent 0.2 meter difference in y coordinate wrt the GRIB data when transforming lat/lon to x/y 
+# Note this WKT string gives consistent 0.2 meter difference in y coordinate wrt the GRIB data when transforming lat/lon to x/y
 PROJECTION_WKT = """
 PROJCRS["DMI HARMONIE IG lambert projection",
     BASEGEOGCRS["DMI HARMONIE IG lambert CRS",

--- a/zarr_creator/config_ig.py
+++ b/zarr_creator/config_ig.py
@@ -6,67 +6,67 @@ from collections import OrderedDict
 from .transforms import derive_orography_from_geopotential
 
 PROJECTION_IDENTIFIER = "ig_projection"
+# Note this WKT string gives consistent 0.2 meter difference in y coordinate wrt the GRIB data when transforming lat/lon to x/y 
 PROJECTION_WKT = """
 PROJCRS["DMI HARMONIE IG lambert projection",
     BASEGEOGCRS["DMI HARMONIE IG lambert CRS",
         DATUM["DMI HARMONIE IG lambert datum",
             ELLIPSOID["Sphere", 6371229, 0,
-                LENGTHUNIT["metre", 1,
-                    ID["EPSG", 9001]
+                LENGTHUNIT["metre",1,
+                    ID["EPSG",9001]
                 ]
             ]
         ],
-        PRIMEM["Greenwich", 0,
-            ANGLEUNIT["degree", 0.0174532925199433,
-                ID["EPSG", 9122]
-            ]
+        PRIMEM["Greenwich",0,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8901]
         ]
     ],
     CONVERSION["Lambert Conic Conformal (2SP)",
         METHOD["Lambert Conic Conformal (2SP)",
-            ID["EPSG", 9802]
+            ID["EPSG",9802]
         ],
-        PARAMETER["Latitude of false origin", 55.5,
-            ANGLEUNIT["degree", 0.0174532925199433,
-                ID["EPSG", 8821]
-            ]
+        PARAMETER["Latitude of false origin",72,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8821]
         ],
-        PARAMETER["Longitude of false origin", -8,
-            ANGLEUNIT["degree", 0.0174532925199433,
-                ID["EPSG", 8822]
-            ]
+        PARAMETER["Longitude of false origin",324,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8822]
         ],
-        PARAMETER["Latitude of 1st standard parallel", 55.5,
-            ANGLEUNIT["degree", 0.0174532925199433,
-                ID["EPSG", 8823]
-            ]
+        PARAMETER["Latitude of 1st standard parallel",72,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8823]
         ],
-        PARAMETER["Latitude of 2nd standard parallel", 55.5,
-            ANGLEUNIT["degree", 0.0174532925199433,
-                ID["EPSG", 8824]
-            ]
+        PARAMETER["Latitude of 2nd standard parallel",72,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8824]
         ],
-        PARAMETER["Easting at false origin", 0,
-            LENGTHUNIT["metre", 1],
-            ID["EPSG", 8826]
+        PARAMETER["Easting at false origin",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8826]
         ],
-        PARAMETER["Northing at false origin", 0,
-            LENGTHUNIT["metre", 1],
-            ID["EPSG", 8827]
+        PARAMETER["Northing at false origin",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8827]
         ]
     ],
-    CS[Cartesian, 2],
-    AXIS["(E)", east,
+    CS[Cartesian,2],
+    AXIS["(E)",east,
         ORDER[1],
-        LENGTHUNIT["Metre", 1]
+        LENGTHUNIT["metre",1,
+            ID["EPSG",9001]
+        ]
     ],
-    AXIS["(N)", north,
+    AXIS["(N)",north,
         ORDER[2],
-        LENGTHUNIT["Metre", 1]
-    ],
+        LENGTHUNIT["metre",1,
+            ID["EPSG",9001]
+        ]
+    ]
     USAGE[
-        AREA["Denmark and surrounding regions"],
-        BBOX[37, -43, 70, 40],
+        AREA["Greenland and surrounding regions"],
+        BBOX[55, 250, 87, -398],
         SCOPE["IG Harmonie forecast projection"]
     ]
 ]

--- a/zarr_creator/read_source.py
+++ b/zarr_creator/read_source.py
@@ -17,7 +17,12 @@ if REFS_ROOT_PATH is None:
     )
 
 
-def read_level_type_data(t_analysis: datetime.datetime, level_type: str) -> xr.Dataset:
+def read_level_type_data(
+    t_analysis: datetime.datetime,
+    level_type: str,
+    projection_identifier: str,
+    projection_wkt: str,
+) -> xr.Dataset:
     if t_analysis.tzinfo is None:
         t_analysis = t_analysis.replace(tzinfo=datetime.timezone.utc)
     t_analysis_utc = t_analysis.astimezone(datetime.timezone.utc)
@@ -69,7 +74,7 @@ def read_level_type_data(t_analysis: datetime.datetime, level_type: str) -> xr.D
         ds["lsm"] = ds.isel(time=0).lsm
 
     # add cf-complicant projection information
-    _add_projection_info(ds)
+    _add_projection_info(ds, projection_identifier, projection_wkt)
 
     # set cf-compliant standard_name for axes time, x and y
     ds.time.attrs["standard_name"] = "time"
@@ -79,83 +84,18 @@ def read_level_type_data(t_analysis: datetime.datetime, level_type: str) -> xr.D
     return ds
 
 
-# based on
-# https://opendatadocs.dmi.govcloud.dk/Data/Forecast_Data_Weather_Model_HARMONIE_DINI_IG,
-# but modified to include USAGE section with BBOX that cartopy requires
-DINI_CRS_WKT = """
-PROJCRS["DMI HARMONIE DINI lambert projection",
-    BASEGEOGCRS["DMI HARMONIE DINI lambert CRS",
-        DATUM["DMI HARMONIE DINI lambert datum",
-            ELLIPSOID["Sphere", 6371229, 0,
-                LENGTHUNIT["metre", 1,
-                    ID["EPSG", 9001]
-                ]
-            ]
-        ],
-        PRIMEM["Greenwich", 0,
-            ANGLEUNIT["degree", 0.0174532925199433,
-                ID["EPSG", 9122]
-            ]
-        ]
-    ],
-    CONVERSION["Lambert Conic Conformal (2SP)",
-        METHOD["Lambert Conic Conformal (2SP)",
-            ID["EPSG", 9802]
-        ],
-        PARAMETER["Latitude of false origin", 55.5,
-            ANGLEUNIT["degree", 0.0174532925199433],
-            ID["EPSG", 8821]
-        ],
-        PARAMETER["Longitude of false origin", -8,
-            ANGLEUNIT["degree", 0.0174532925199433],
-            ID["EPSG", 8822]
-        ],
-        PARAMETER["Latitude of 1st standard parallel", 55.5,
-            ANGLEUNIT["degree", 0.0174532925199433],
-            ID["EPSG", 8823]
-        ],
-        PARAMETER["Latitude of 2nd standard parallel", 55.5,
-            ANGLEUNIT["degree", 0.0174532925199433],
-            ID["EPSG", 8824]
-        ],
-        PARAMETER["Easting at false origin", 0,
-            LENGTHUNIT["metre", 1],
-            ID["EPSG", 8826]
-        ],
-        PARAMETER["Northing at false origin", 0,
-            LENGTHUNIT["metre", 1],
-            ID["EPSG", 8827]
-        ]
-    ],
-    CS[Cartesian, 2],
-    AXIS["(E)", east,
-        ORDER[1],
-        LENGTHUNIT["Metre", 1]
-    ],
-    AXIS["(N)", north,
-        ORDER[2],
-        LENGTHUNIT["Metre", 1]
-    ],
-    USAGE[
-        AREA["Denmark and surrounding regions"],
-        BBOX[37, -43, 70, 40],
-        SCOPE["DINI Harmonie forecast projection"]
-    ]
-]
+def _add_projection_info(ds, projection_identifier: str, projection_wkt: str | None):
+    if projection_wkt is None:
+        raise ValueError("projection_wkt must be provided for the active suite")
 
-"""
-
-
-def _add_projection_info(ds):
-    PROJECTION_IDENTIFIER = "dini_projection"
     logger.info(
-        f"Adding projection information to dataset with identifier {PROJECTION_IDENTIFIER}"
+        f"Adding projection information to dataset with identifier {projection_identifier}"
     )
-    ds[PROJECTION_IDENTIFIER] = xr.DataArray()
-    ds[PROJECTION_IDENTIFIER].attrs["crs_wkt"] = "".join(DINI_CRS_WKT.splitlines())
+    ds[projection_identifier] = xr.DataArray()
+    ds[projection_identifier].attrs["crs_wkt"] = "".join(projection_wkt.splitlines())
 
     for var_name in ds.data_vars:
-        ds[var_name].attrs["grid_mapping"] = PROJECTION_IDENTIFIER
+        ds[var_name].attrs["grid_mapping"] = projection_identifier
 
 
 def merge_level_specific_params(ds, true_param, level, short_name):
@@ -183,7 +123,15 @@ def main():
 
     args = argparser.parse_args()
 
-    ds = read_level_type_data(t_analysis=args.analysis_time, level_type=args.level_type)
+    projection_identifier = "dummy_projection"
+    projection_wkt = "dummy_wkt"
+
+    ds = read_level_type_data(
+        t_analysis=args.analysis_time,
+        level_type=args.level_type,
+        projection_identifier=projection_identifier,
+        projection_wkt=projection_wkt,
+    )
 
     print(ds)
 

--- a/zarr_creator/write_zarr.py
+++ b/zarr_creator/write_zarr.py
@@ -79,7 +79,10 @@ def write_output_zarrs(
 
     t_analysis_formatted = t_analysis.isoformat().replace(":", "").replace("+0000", "Z")
     prefix = OUTPUT_PREFIX_FORMAT.format(
-        suite_name=suite_name, member=member, t_analysis_formatted=t_analysis_formatted, dataset_id=dataset_id
+        suite_name=suite_name,
+        member=member,
+        t_analysis_formatted=t_analysis_formatted,
+        dataset_id=dataset_id,
     )
 
     fn_local = f"{dataset_id}.zarr"

--- a/zarr_creator/write_zarr.py
+++ b/zarr_creator/write_zarr.py
@@ -11,7 +11,7 @@ from loguru import logger
 
 BUCKET_NAME = "harmonie-zarr"
 BUCKET_REGION = "eu-central-1"
-OUTPUT_PREFIX_FORMAT = "dini/{member}/{t_analysis_formatted}/{dataset_id}.zarr"
+OUTPUT_PREFIX_FORMAT = "{suite_name}/{member}/{t_analysis_formatted}/{dataset_id}.zarr"
 
 
 def write_output_zarrs(
@@ -20,6 +20,7 @@ def write_output_zarrs(
     rechunk_to: dict,
     member: str,
     t_analysis: datetime.datetime,
+    suite_name: str,
     skip_s3_bucket_upload: bool = False,
     local_copy_path: str = None,
 ):
@@ -42,6 +43,8 @@ def write_output_zarrs(
         The forecast member name, e.g. "control"
     t_analysis : datetime.datetime
         The analysis time of the forecast.
+    suite_name : str
+        The name of the forecast suite, e.g. "dini" or "ig"
     skip_s3_bucket_upload : bool, optional
         If True, skip uploading the output zarr dataset to S3.
     local_copy_path : str, optional
@@ -76,7 +79,7 @@ def write_output_zarrs(
 
     t_analysis_formatted = t_analysis.isoformat().replace(":", "").replace("+0000", "Z")
     prefix = OUTPUT_PREFIX_FORMAT.format(
-        member=member, t_analysis_formatted=t_analysis_formatted, dataset_id=dataset_id
+        suite_name=suite_name, member=member, t_analysis_formatted=t_analysis_formatted, dataset_id=dataset_id
     )
 
     fn_local = f"{dataset_id}.zarr"


### PR DESCRIPTION
This PR adds support for multiple data sources, including IG. Separate config files are used for each suite, and some hardcoded decisions are moved to the configs.

closes #31 